### PR TITLE
Nix-ify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 *.iml
 target
+result
 *.lock

--- a/README.md
+++ b/README.md
@@ -2,11 +2,37 @@
 
 A scramble generator for 3x3 Rubik's Cubes.
 
-## Random Move Generator
+## Install
+
+### With Nix
+
+Initialize `Cargo.lock`:
+```sh
+$ nix-shell --command 'cargo update'
+```
+or the convenience script `generate_lockfile.sh`.
+
+Install:
+```sh
+$ nix-env -i -f default.nix
+```
+
+Enter a development environment providing the same rust version:
+```sh
+$ nix-shell
+```
+
+### Manually
+
+Just use `cargo` like normal.
+
+## Usage
+
+### Random Move Generator
 
 Choose sequence of random moves, with a heuristic to avoid immediate repeat
 moves.
 
-## IDA*
+### IDA*
 
 Coming soon!

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+let
+  mozilla-pkgs = import (builtins.fetchTarball
+    https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> {
+    overlays = [
+      mozilla-pkgs (self: super:
+      {
+        rustc = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
+        cargo = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
+      })
+    ];
+  };
+  naersk = pkgs.callPackage (builtins.fetchGit {
+    name = "HEAD";
+    url = "https://github.com/nix-community/naersk";
+    ref = "HEAD";
+    rev = "df71f5e4babda41cd919a8684b72218e2e809fa9";
+  }) {};
+in naersk.buildPackage ./.

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ let
     ];
   };
   naersk = pkgs.callPackage (builtins.fetchGit {
-    name = "HEAD";
+    name = "master";
     url = "https://github.com/nix-community/naersk";
     ref = "HEAD";
     rev = "df71f5e4babda41cd919a8684b72218e2e809fa9";

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,5 @@
 let
-  mozilla-pkgs = import (builtins.fetchTarball
-    https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
-  pkgs = import <nixpkgs> {
-    overlays = [
-      mozilla-pkgs (self: super:
-      {
-        rustc = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
-        cargo = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
-      })
-    ];
-  };
+  pkgs = import ./rust_toolchain.nix;
   naersk = pkgs.callPackage (builtins.fetchGit {
     name = "master";
     url = "https://github.com/nix-community/naersk";

--- a/generate_lockfile.sh
+++ b/generate_lockfile.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+nix-shell --command 'cargo update'

--- a/rust_toolchain.nix
+++ b/rust_toolchain.nix
@@ -1,0 +1,13 @@
+let
+  mozilla-pkgs = import (builtins.fetchTarball
+    https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> {
+    overlays = [
+      mozilla-pkgs (self: super:
+      {
+        rustc = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
+        cargo = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
+      })
+    ];
+  };
+in pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+let
+  mozilla-pkgs = import (builtins.fetchTarball
+    https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> {
+    overlays = [
+      mozilla-pkgs (self: super:
+      {
+        rustc = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
+        cargo = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
+      })
+    ];
+  };
+in pkgs.mkShell {
+  inputsFrom = with pkgs; [ rustc cargo ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,5 @@
-let
-  mozilla-pkgs = import (builtins.fetchTarball
-    https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
-  pkgs = import <nixpkgs> {
-    overlays = [
-      mozilla-pkgs (self: super:
-      {
-        rustc = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
-        cargo = (self.rustChannelOf { rustToolchain = ./rust-toolchain; }).rust;
-      })
-    ];
-  };
-in pkgs.mkShell {
+{ pkgs ? import ./rust_toolchain.nix }:
+
+pkgs.mkShell {
   inputsFrom = with pkgs; [ rustc cargo ];
 }


### PR DESCRIPTION
Add nix build files. `shell.nix` is for development and for bootstrapping---to initially generate `Cargo.lock` in a newly cloned installation.